### PR TITLE
fixed server adress in client

### DIFF
--- a/client-server/cs_demo_client.c
+++ b/client-server/cs_demo_client.c
@@ -24,7 +24,7 @@ int main(int argc, const char *argv[])
     exit(EXIT_FAILURE);
   }
 
-  char end_point[256];
+  char end_point[256] = "";
   strcat(end_point, "opc.tcp://");
   strcat(end_point, argv[1]);
   strcat(end_point, ":4840");


### PR DESCRIPTION
@Mariunil  the address string was already containing an @ character for some reason, so the constructed address therefore has a leading @ which leads to an invalid server adress problem, which made this example not work (seen in at least many cases (maybe all) this semester). Initializing to "" worked for me to fix the issue.